### PR TITLE
Bumped release

### DIFF
--- a/znapzend/znapzend.spec
+++ b/znapzend/znapzend.spec
@@ -1,6 +1,6 @@
 Name: znapzend
 Version: 0.19.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: zfs backup with remote capabilities and mbuffer integration
 License: GPLv3+
 URL: http://www.znapzend.org


### PR DESCRIPTION
dnf seems to get confused by the fact, that there are a couple of builds with the same version '0.19.1-1.fc28' available at 'oranenj/znapzend'. It seems to pull the oldest version that built ok which results in:

```
"slurp" is not exported by the Mojo::Util module
Can't continue after import errors at /usr/share/perl5/vendor_perl/ZnapZend.pm line 5.
BEGIN failed--compilation aborted at /usr/share/perl5/vendor_perl/ZnapZend.pm line 5.
Compilation failed in require at /usr/bin/znapzend line 9.
BEGIN failed--compilation aborted at /usr/bin/znapzend line 9
```

(and some missing required packages). This should be fixed by a simple version bump since there's already a proper patch that addresses the slurp issue (`00_remove_deprecated_slurp.patch`) and proper `build requires`.

Removing other builds with version '0.19.1-1.fc28' so there's only one left in copr should work fine as well.